### PR TITLE
Remove unmaintained matches crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ doctest = false
 
 [dependencies]
 cssparser = "0.27"
-matches = "0.1.10"
 html5ever = "0.26.0"
 selectors = "0.22"
 indexmap = "1.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@ Kuchikiki (口利き) is an HTML tree manipulation library for Rust.
 
 #[macro_use]
 extern crate html5ever;
-#[macro_use]
-extern crate matches;
 
 mod attributes;
 mod cell_extras;


### PR DESCRIPTION
Removing the import unshadows `std::matches` which does the same thing since rust 1.42.