### PR TITLE
Run ci on the speedreader branch as well

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - speedreader
     pull_request:
 
 jobs:


### PR DESCRIPTION
While we're maintaining a separate branch for brave-core use, make sure we get ongoing build/test feedback for both supported branches.