### PR TITLE
github actions: Remove dtolnay/rust-toolchain script

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,12 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Toolchain # TODO: remove this one
-        uses: dtolnay/rust-toolchain@1482605bfc5719782e1267fd0c0cc350fe7646b8 # v1
-        with:
-          components: clippy, rustfmt
-          toolchain: stable
-
       - name: Cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,4 +19,3 @@ jobs:
         run: cargo build
       - name: Test
         run: cargo test
-


### PR DESCRIPTION
This is unnecessary since the base image includes the current stable rust toolchain with the associated components.

If we want to test on specific versions, `rustup` is also included and can be used to install those.

Follow-up to #33 todo and associated discussion. 