### PR TITLE
Allow clippy::result_unit_err for now

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,9 @@
 //! Node iterators
 
+// Addressing this lint is a semver-breaking change.
+// Remove this once the issue has been addressed.
+#![allow(clippy::result_unit_err)]
+
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::iter::Rev;

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,3 +1,7 @@
+// Addressing this lint is a semver-breaking change.
+// Remove this once the issue has been addressed.
+#![allow(clippy::result_unit_err)]
+
 use crate::attributes::ExpandedName;
 use crate::iter::{NodeIterator, Select};
 use crate::node_data_ref::NodeDataRef;


### PR DESCRIPTION
This is a reasonable warning, but resolving it (#9) breaks semver, and it's taking time to get down the priority list to addressing it. Allow the warning for now so it stops polluting ci feedback.