### PR TITLE
Downgrade the html5ever dep to 0.25.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 cssparser = "0.27"
 matches = "0.1.4"
-html5ever = "0.26.0"
+html5ever = "0.25.1"
 selectors = "0.22"
 indexmap = "1.6.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuchikiki"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
   "Brave Authors",
   "Ralph Giles <rgiles@brave.com>",


### PR DESCRIPTION
This works fine in practice and maintains compatibility with the speedreader code in brave-core.