### PR TITLE
Implement Attributes::remove with IndexMap::swap_remove

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -78,6 +78,6 @@ impl Attributes {
 
     /// Like IndexMap::remove
     pub fn remove<A: Into<LocalName>>(&mut self, local_name: A) -> Option<Attribute> {
-        self.map.remove(&ExpandedName::new(ns!(), local_name))
+        self.map.swap_remove(&ExpandedName::new(ns!(), local_name))
     }
 }


### PR DESCRIPTION
Use the explicit call instead of the deprecated `remove` method. This has the same behaviour as the previous call, so there is no change to the public API.

The intent it so make explicit that the call swaps the last element in the map into the place of the removed element, which is O(1), vs. `shift_remove` which maintains ordering but is O(n).

Addresses a deprecation warning with indexmap v2.2.6.