### PR TITLE
impl Display for NodeRef

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,10 +1,10 @@
 use html5ever::serialize::TraversalScope::*;
 use html5ever::serialize::{serialize, Serialize, SerializeOpts, Serializer, TraversalScope};
 use html5ever::QualName;
-use std::io;
-use std::io::Write;
 use std::fmt;
 use std::fs::File;
+use std::io;
+use std::io::Write;
 use std::path::Path;
 
 use crate::tree::{NodeData, NodeRef};


### PR DESCRIPTION
Replace the `std::string::ToString` impl with `std::fmt::Display`. `ToString` is implemented in the std library for all `Display` types, so documentation recommends implementing the more general trait instead.

The new trait method is fallible, returning `fmt::Error` instead of `unwrap()` on serialization failure, but the blanket `to_string` impl converts this to a panic so the only behavior change is a less-localized error message. Serialization shouldn't fail so this isn't a major concern.

The different `Result` types are explicitly namespaced at each reference for clarity between the different variants.

Addresses a clippy lint.