### PR TITLE
Fix doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [lib]
 name = "kuchikiki"
-doctest = false
 
 [dependencies]
 cssparser = "0.27"

--- a/src/cell_extras.rs
+++ b/src/cell_extras.rs
@@ -15,7 +15,10 @@
 //!   because it would involve running arbitrary code through `T::clone`
 //!   and provide that code with a reference to the inside of the cell.
 //!
-//! ```rust
+//! ```rust,compile_fail
+//! # use std::cell::Cell;
+//! # use std::mem;
+//! # use std::rc::Rc;
 //! struct Evil(Box<u32>, Rc<Cell<Option<Evil>>>);
 //! impl Clone for Evil {
 //!     fn clone(&self) -> Self {
@@ -41,6 +44,7 @@
 //! would require temporarily replacing it with a default value:
 //!
 //! ```rust
+//! # use std::cell::Cell;
 //! fn option_dance<T, F, R>(cell: &Cell<T>, f: F) -> R
 //!     where T: Default, F: FnOnce(&mut T) -> R
 //! {


### PR DESCRIPTION
Doctests have always been disabled in this repo. Add sufficient annotations so that they pass and re-enable them.

As far as I can tell, the first `cell_extras` example is not supposed to compile, demonstrating the soundness of the extension trait. Perhaps this is why the tests were disabled. It looks like the `compile_fail` annotation was stablized in 2017 with rust 1.22.0.