### PR TITLE
Port recent fixes to the speedreader branch

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,23 +1,22 @@
-name: Audit
+name: Security audit
+
 on:
   push:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
-    branches:
-      - main
-      - speedreader
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   schedule:
     - cron: '21 20 2 * *'
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,15 +1,14 @@
 name: Lint
+
 on:
   push:
     branches:
       - main
       - speedreader
   pull_request:
-    branches:
-      - main
-      - speedreader
   schedule:
     - cron: '28 20 2 * *'
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -17,22 +16,13 @@ jobs:
       checks: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          components: clippy, rustfmt
-          toolchain: stable
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       - name: Format
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets
+        run: cargo clippy --all-targets

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,18 +5,17 @@ on:
     branches:
       - main
       - speedreader
-    pull_request:
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
       - name: Build
         run: cargo build
       - name: Test
         run: cargo test
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 
 [lib]
 name = "kuchikiki"
-doctest = false
 
 [dependencies]
 cssparser = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuchikiki"
-version = "0.8.4-speedreader"
+version = "0.8.5-speedreader"
 authors = [
   "Brave Authors",
   "Ralph Giles <rgiles@brave.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cssparser = "0.27"
 matches = "0.1.4"
 html5ever = "0.25.1"
 selectors = "0.22"
-indexmap = { version = "1.9.3", features = [ "std" ] }
+indexmap = "2.2.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -78,6 +78,6 @@ impl Attributes {
 
     /// Like IndexMap::remove
     pub fn remove<A: Into<LocalName>>(&mut self, local_name: A) -> Option<Attribute> {
-        self.map.remove(&ExpandedName::new(ns!(), local_name))
+        self.map.swap_remove(&ExpandedName::new(ns!(), local_name))
     }
 }

--- a/src/cell_extras.rs
+++ b/src/cell_extras.rs
@@ -15,7 +15,10 @@
 //!   because it would involve running arbitrary code through `T::clone`
 //!   and provide that code with a reference to the inside of the cell.
 //!
-//! ```rust
+//! ```rust,compile_fail
+//! # use std::cell::Cell;
+//! # use std::mem;
+//! # use std::rc::Rc;
 //! struct Evil(Box<u32>, Rc<Cell<Option<Evil>>>);
 //! impl Clone for Evil {
 //!     fn clone(&self) -> Self {
@@ -41,6 +44,7 @@
 //! would require temporarily replacing it with a default value:
 //!
 //! ```rust
+//! # use std::cell::Cell;
 //! fn option_dance<T, F, R>(cell: &Cell<T>, f: F) -> R
 //!     where T: Default, F: FnOnce(&mut T) -> R
 //! {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,10 +1,11 @@
 use html5ever::serialize::TraversalScope::*;
 use html5ever::serialize::{serialize, Serialize, SerializeOpts, Serializer, TraversalScope};
 use html5ever::QualName;
+use std::io;
+use std::io::Write;
+use std::fmt;
 use std::fs::File;
-use std::io::{Result, Write};
 use std::path::Path;
-use std::string::ToString;
 
 use crate::tree::{NodeData, NodeRef};
 
@@ -13,7 +14,7 @@ impl Serialize for NodeRef {
         &self,
         serializer: &mut S,
         traversal_scope: TraversalScope,
-    ) -> Result<()> {
+    ) -> io::Result<()> {
         match (traversal_scope, self.data()) {
             (ref scope, NodeData::Element(element)) => {
                 if *scope == IncludeNode {
@@ -71,19 +72,21 @@ impl Serialize for NodeRef {
     }
 }
 
-impl ToString for NodeRef {
+impl fmt::Display for NodeRef {
     #[inline]
-    fn to_string(&self) -> String {
-        let mut u8_vec = Vec::new();
-        self.serialize(&mut u8_vec).unwrap();
-        String::from_utf8(u8_vec).unwrap()
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Call the html serializer for the node (sub)tree.
+        let mut bytes = Vec::new();
+        self.serialize(&mut bytes).or(Err(fmt::Error))?;
+        let html = String::from_utf8(bytes).or(Err(fmt::Error))?;
+        f.write_str(&html)
     }
 }
 
 impl NodeRef {
     /// Serialize this node and its descendants in HTML syntax to the given stream.
     #[inline]
-    pub fn serialize<W: Write>(&self, writer: &mut W) -> Result<()> {
+    pub fn serialize<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         serialize(
             writer,
             self,
@@ -96,7 +99,7 @@ impl NodeRef {
 
     /// Serialize this node and its descendants in HTML syntax to a new file at the given path.
     #[inline]
-    pub fn serialize_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+    pub fn serialize_to_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let mut file = File::create(&path)?;
         self.serialize(&mut file)
     }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,10 +1,10 @@
 use html5ever::serialize::TraversalScope::*;
 use html5ever::serialize::{serialize, Serialize, SerializeOpts, Serializer, TraversalScope};
 use html5ever::QualName;
-use std::io;
-use std::io::Write;
 use std::fmt;
 use std::fs::File;
+use std::io;
+use std::io::Write;
 use std::path::Path;
 
 use crate::tree::{NodeData, NodeRef};


### PR DESCRIPTION
- Migrate to indexmap v2.2.6 (resolves #45)
- Fix doctests (backport #55)
- Address clippy warnings (backport #53, #54)
- Align github actions scripts to reduce diff noise
- Bump version for pre-release testing