### PR TITLE
QualName similar names, but are actually distinct types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 license = "MIT"
 description = "(口利き) HTML tree manipulation library"
 repository = "https://github.com/brave/kuchikiki"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "kuchikiki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 name = "kuchikiki"
 
 [dependencies]
-cssparser = "0.34.0"
+cssparser = "0.27.0"
 html5ever = "0.27.0"
 selectors = "0.22"
 indexmap = "2.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 name = "kuchikiki"
 
 [dependencies]
-cssparser = "0.27"
+cssparser = "0.34.0"
 html5ever = "0.27.0"
 selectors = "0.22"
 indexmap = "2.2.6"


### PR DESCRIPTION
## Original Branch
This issue also persists in the [original repo](https://github.com/kuchiki-rs/kuchiki/issues/94) when creating a new element.

## The issue
Well, markup5ever and html5ever both have QualName, but html5ever just re-exports QualName from markup5ever.

And because kuchikiki keeps pulling the 0.26.0 version of html5ever, it's not compatible with newer projects that use anything above 0.26.0.