### PR TITLE
Update `selectors` crate to 0.25, and enables `:has` and `:is` selectors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 name = "kuchikiki"
 
 [dependencies]
-cssparser = "0.28"
+cssparser = "0.31"
 html5ever = "0.27.0"
-selectors = "0.23"
+selectors = "0.25"
 indexmap = "2.2.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 name = "kuchikiki"
 
 [dependencies]
-cssparser = "0.27"
+cssparser = "0.28"
 html5ever = "0.27.0"
-selectors = "0.22"
+selectors = "0.23"
 indexmap = "2.2.6"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod tree;
 pub use attributes::{Attribute, Attributes, ExpandedName};
 pub use node_data_ref::NodeDataRef;
 pub use parser::{parse_fragment, parse_html, parse_html_with_options, ParseOpts, Sink};
-pub use select::{Selector, Selectors, Specificity};
+pub use select::{Selector, SelectorCache, Selectors, Specificity};
 pub use tree::{Doctype, DocumentData, ElementData, Node, NodeData, NodeRef};
 
 /// This module re-exports a number of traits that are useful when using Kuchikiki.

--- a/src/select.rs
+++ b/src/select.rs
@@ -10,13 +10,13 @@ use cssparser::{self, CowRcStr, ParseError, SourceLocation, ToCss};
 use html5ever::{LocalName, Namespace};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::context::{IgnoreNthChildForInvalidation, NeedsSelectorFlags, QuirksMode};
-use selectors::parser::{ParseRelative, SelectorParseErrorKind};
+use selectors::matching::ElementSelectorFlags;
 use selectors::parser::{
     NonTSPseudoClass, Parser, Selector as GenericSelector, SelectorImpl, SelectorList,
 };
+use selectors::parser::{ParseRelative, SelectorParseErrorKind};
 use selectors::{self, matching, NthIndexCache, OpaqueElement};
 use std::{fmt, fmt::Write, ops::Deref};
-use selectors::matching::ElementSelectorFlags;
 
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 ///
@@ -26,7 +26,10 @@ static SELECTOR_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r', '\x0C'];
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
 pub struct CssString(pub String);
 impl ToCss for CssString {
-    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: Write {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
+    where
+        W: Write,
+    {
         dest.write_str(&self.0)
     }
 }
@@ -50,7 +53,10 @@ impl Deref for CssString {
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
 pub struct CssLocalName(pub LocalName);
 impl ToCss for CssLocalName {
-    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: Write {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
+    where
+        W: Write,
+    {
         write!(dest, "{}", self.0)
     }
 }
@@ -379,8 +385,7 @@ impl selectors::Element for NodeDataRef<ElementData> {
     }
 
     fn first_element_child(&self) -> Option<Self> {
-        self
-            .as_node()
+        self.as_node()
             .children()
             .flat_map(|x| x.into_element_ref())
             .next()

--- a/src/select.rs
+++ b/src/select.rs
@@ -90,6 +90,22 @@ impl<'i> Parser<'i> for KuchikiParser {
     type Impl = KuchikiSelectors;
     type Error = SelectorParseErrorKind<'i>;
 
+    fn parse_nth_child_of(&self) -> bool {
+        true
+    }
+
+    fn parse_is_and_where(&self) -> bool {
+        true
+    }
+
+    fn parse_has(&self) -> bool {
+        true
+    }
+
+    fn parse_parent_selector(&self) -> bool {
+        true
+    }
+
     fn parse_non_ts_pseudo_class(
         &self,
         location: SourceLocation,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,11 +2,11 @@ use html5ever::tree_builder::QuirksMode;
 use html5ever::QualName;
 use std::path::Path;
 
-use tempfile::TempDir;
-use crate::NodeRef;
 use crate::parser::{parse_fragment, parse_html};
 use crate::select::*;
 use crate::traits::*;
+use crate::NodeRef;
+use tempfile::TempDir;
 
 #[test]
 fn text_nodes() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ use html5ever::QualName;
 use std::path::Path;
 
 use tempfile::TempDir;
-
+use crate::NodeRef;
 use crate::parser::{parse_fragment, parse_html};
 use crate::select::*;
 use crate::traits::*;
@@ -169,6 +169,74 @@ fn select_first() {
     );
 
     assert!(document.select_first("p.bar").is_err());
+}
+
+fn check_only_match(document: &NodeRef, selector: &str, text: &str) {
+    let mut matching = document.select(selector).unwrap();
+    let child = matching.next().unwrap().as_node().first_child().unwrap();
+    assert_eq!(&**child.as_text().unwrap().borrow(), text);
+    assert!(matching.next().is_none());
+}
+
+#[test]
+fn select_advanced_has() {
+    let html = r#"
+        <title>Test case</title>
+        <p class=foo>Non-target elem</p>
+        <p class=foo>Elem 1<span class=test-has>a</span></p>
+        <p>Bar</p>
+        <p class="foo bar">Elem 2<a></a></p>
+    "#;
+
+    let document = parse_html().one(html);
+
+    // check :has functionality
+    check_only_match(&document, "p.foo:has(.test-has)", "Elem 1");
+    check_only_match(&document, "p.bar:has(a)", "Elem 2");
+    assert!(document.select_first("p.foo:has(.bar)").is_err());
+}
+
+#[test]
+fn select_advanced_is() {
+    let html = r#"
+        <title>Test case</title>
+        <p class=foo>Non-target elem</p>
+        <p class="foo baz">Non-target elem</p>
+        <p class="foo bar">Elem 1</p>
+        <p class="foo baz no">Elem 2</p>
+    "#;
+
+    let document = parse_html().one(html);
+
+    // check :is functionality
+    check_only_match(&document, "p.foo:is(.bar)", "Elem 1");
+    check_only_match(&document, "p.foo:is(.no)", "Elem 2");
+    check_only_match(&document, ".bar:is(p)", "Elem 1");
+}
+
+#[test]
+fn select_advanced_nth_child() {
+    let html = r#"
+        <title>Test case</title>
+        <section class=outer>
+            <p>Elem 1</p>
+            <p>Elem 2</p>
+            <p>Elem 3</p>
+            <p>Elem 4</p>
+            <p>Elem 5</p>
+        </section>
+        <p class=foo>Non-target elem</p>
+        <p class="foo baz">Non-target elem</p>
+        <p class="foo bar">Elem 1</p>
+        <p class="foo baz no">Non-target elem</p>
+    "#;
+
+    let document = parse_html().one(html);
+
+    // check :nth-child functionality
+    check_only_match(&document, ".outer > p:first-child", "Elem 1");
+    check_only_match(&document, ".outer > p:nth-child(3)", "Elem 3");
+    check_only_match(&document, ".outer > p:last-child", "Elem 5");
 }
 
 #[test]


### PR DESCRIPTION
This is a (very minor) breaking change to the API because it adds a new field to the `Select` iterator in order to add caching for `:nth-child`.

If this is not wanted, don't pull the last commit `da1d495407d5e8b5801172e1061db528fe9e0ffa`.