### PR TITLE
Update html5ever

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 name = "kuchikiki"
 
 [dependencies]
-cssparser = "0.29"
-html5ever = "0.29.1"
-selectors = "0.24"
+cssparser = "0.29.0"
+html5ever = "0.36.1"
+selectors = "0.24.0"
 indexmap = "2.6.0"
 
 [dev-dependencies]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -56,7 +56,7 @@ pub fn parse_fragment_with_options(
         tokenizer: opts.tokenizer,
         tree_builder: opts.tree_builder,
     };
-    html5ever::parse_fragment(sink, html5opts, ctx_name, ctx_attr)
+    html5ever::parse_fragment(sink, html5opts, ctx_name, ctx_attr, true)
 }
 
 /// Receives new tree nodes during parsing.


### PR DESCRIPTION
Closes https://github.com/brave/kuchikiki/issues/78
Superseeds and closes https://github.com/brave/kuchikiki/pull/64

The only change in upgrading the dependency was that `context_element_allows_scripting` was moved out of `TreeBuilderOpts` (which was inside `ParseOpts`) into an argument. We only use the default `ParseOpts::default()`, which defaulted this field to `true`. So no behavior change.